### PR TITLE
Added Mix (prev StumbleUpon), Tumblr and Reddit. Removed Google Plus. Fixed Twitter. Fixed pages without URLs. 

### DIFF
--- a/src/SimpleSharing.php
+++ b/src/SimpleSharing.php
@@ -120,8 +120,11 @@ class SimpleSharing extends Plugin
         $optionsPlatforms = [
             'facebook' => 'Facebook',
             'twitter' => 'Twitter',
-            'google' => 'Google',
             'linkedin' => 'LinkedIn',
+            'pinterest' => 'Pinterest',
+            'stumbleUpon' => 'StumbleUpon',
+            'tumblr' => 'Tumblr',
+            'reddit' => 'Reddit',
         ];
 
         return Craft::$app->view->renderTemplate(

--- a/src/SimpleSharing.php
+++ b/src/SimpleSharing.php
@@ -121,8 +121,8 @@ class SimpleSharing extends Plugin
             'facebook' => 'Facebook',
             'twitter' => 'Twitter',
             'linkedin' => 'LinkedIn',
-            'pinterest' => 'Pinterest',
-            'stumbleUpon' => 'StumbleUpon',
+//            'pinterest' => 'Pinterest',
+            'mix' => 'Mix',
             'tumblr' => 'Tumblr',
             'reddit' => 'Reddit',
         ];

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -49,10 +49,10 @@ class DefaultController extends Controller
 
                 $links = [
                     'facebook' => '<a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=' . $encodedUrl . '">Facebook</a>',
-                    'twitter' => '<a target="_blank" href="https://twitter.com/home?status=' . $encodedUrl . '">Twitter</a>',
-                    'linkedin' => '<a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&title=' . $encodedUrl . '&summary=&source=&url=' . $encodedUrl . '">LinkedIn</a>',
-                    'pinterest' => '<a target="_blank" href="https://www.pinterest.com/pin/create/link/?' . $encodedUrl . '">Pinterest</a>',
-                    'stumbleupon' => '<a target="_blank" href="https://www.stumbleupon.com/submit/?' . $encodedUrl . '">StumbleUpon</a>',
+                    'twitter' => '<a target="_blank" href="https://twitter.com/intent/tweet?text=' . $encodedUrl . '">Twitter</a>',
+                    'linkedin' => '<a target="_blank" href="https://www.linkedin.com/shareArticle?title=' . $encodedUrl . '&summary=&source=&url=' . $encodedUrl . '">LinkedIn</a>',
+//                    'pinterest' => '<a target="_blank" href="http://pinterest.com/pin/create/link/?media=aaa&url=' . $encodedUrl . '">Pinterest</a>',
+                    'mix' => '<a target="_blank" href="https://mix.com/add?url=' . $encodedUrl . '">Mix</a>',
                     'tumblr' => '<a target="_blank" href="https://www.tumblr.com/share/link?' . $encodedUrl . '">Tumblr</a>',
                     'reddit' => '<a target="_blank" href="http://www.reddit.com/submit?url=' . $encodedUrl . '">Reddit</a>',
                 ];

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -42,9 +42,10 @@ class DefaultController extends Controller
             /** @var Entry|null $entry */
             $entry = Craft::$app->getEntries()->getEntryById($data['id']);
 
-            if (null !== $entry && $entry->url) {
+            if (null !== $entry && trim((string)$entry->url)) {
+
                 $btns = [];
-                $encodedUrl = urlEncode($entry->url);
+                $encodedUrl = urlencode(trim($entry->url));
 
                 $links = [
                     'facebook' => '<a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=' . $encodedUrl . '">Facebook</a>',

--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -42,13 +42,18 @@ class DefaultController extends Controller
             /** @var Entry|null $entry */
             $entry = Craft::$app->getEntries()->getEntryById($data['id']);
 
-            if (null !== $entry) {
+            if (null !== $entry && $entry->url) {
                 $btns = [];
+                $encodedUrl = urlEncode($entry->url);
+
                 $links = [
-                    'facebook' => '<a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=' . $entry->url . '">Facebook</a>',
-                    'twitter' => '<a target="_blank" href="https://twitter.com/home?status=' . $entry->url . '">Twitter</a>',
-                    'linkedin' => '<a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&title=' . $entry->url . '&summary=&source=&url=' . $entry->url . '">LinkedIn</a>',
-                    'google' => '<a target="_blank" href="https://plus.google.com/share?url=' . $entry->url . '">Google</a>',
+                    'facebook' => '<a target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=' . $encodedUrl . '">Facebook</a>',
+                    'twitter' => '<a target="_blank" href="https://twitter.com/home?status=' . $encodedUrl . '">Twitter</a>',
+                    'linkedin' => '<a target="_blank" href="https://www.linkedin.com/shareArticle?mini=true&title=' . $encodedUrl . '&summary=&source=&url=' . $encodedUrl . '">LinkedIn</a>',
+                    'pinterest' => '<a target="_blank" href="https://www.pinterest.com/pin/create/link/?' . $encodedUrl . '">Pinterest</a>',
+                    'stumbleupon' => '<a target="_blank" href="https://www.stumbleupon.com/submit/?' . $encodedUrl . '">StumbleUpon</a>',
+                    'tumblr' => '<a target="_blank" href="https://www.tumblr.com/share/link?' . $encodedUrl . '">Tumblr</a>',
+                    'reddit' => '<a target="_blank" href="http://www.reddit.com/submit?url=' . $encodedUrl . '">Reddit</a>',
                 ];
 
                 foreach ($links as $key => $link) {

--- a/src/variables/SimpleSharingVariable.php
+++ b/src/variables/SimpleSharingVariable.php
@@ -47,16 +47,16 @@ class SimpleSharingVariable
                 return 'https://www.facebook.com/sharer/sharer.php?u='.$encodedUrl;
                 break;
             case 'twitter':
-                return 'https://twitter.com/home?status='.$encodedUrl;
+                return 'https://twitter.com/intent/tweet?text='.$encodedUrl;
                 break;
             case 'linkedin':
                 return 'https://www.linkedin.com/shareArticle?mini=true&title=&summary=&source=&url='.$encodedUrl;
                 break;
-            case 'pinterest':
-                return 'https://www.pinterest.com/pin/create/link/?'.$encodedUrl;
-                break;
-            case 'stumbleupon':
-                return 'https://www.stumbleupon.com/submit/?'.$encodedUrl;
+//            case 'pinterest':
+//                return 'https://www.pinterest.com/pin/create/link/?'.$encodedUrl;
+//                break;
+            case 'mix':
+                return 'https://mix.com/add?url='.$encodedUrl;
                 break;
 			case 'tumblr':
 				return 'https://www.tumblr.com/share/link?'.$encodedUrl;

--- a/src/variables/SimpleSharingVariable.php
+++ b/src/variables/SimpleSharingVariable.php
@@ -35,6 +35,11 @@ class SimpleSharingVariable
      */
     public function link($url, $service)
     {
+
+    	if(!trim($url)) {
+    		return null;
+		}
+
         $encodedUrl = urlencode($url);
 
         switch ($service) {

--- a/src/variables/SimpleSharingVariable.php
+++ b/src/variables/SimpleSharingVariable.php
@@ -35,19 +35,30 @@ class SimpleSharingVariable
      */
     public function link($url, $service)
     {
+        $encodedUrl = urlencode($url);
+
         switch ($service) {
             case 'facebook':
-                return 'https://www.facebook.com/sharer/sharer.php?u='.$url;
+                return 'https://www.facebook.com/sharer/sharer.php?u='.$encodedUrl;
                 break;
             case 'twitter':
-                return 'https://twitter.com/home?status='.$url;
-                break;
-            case 'google':
-                return 'https://plus.google.com/share?url='.$url;
+                return 'https://twitter.com/home?status='.$encodedUrl;
                 break;
             case 'linkedin':
-                return 'https://www.linkedin.com/shareArticle?mini=true&title=&summary=&source=&url='.$url;
+                return 'https://www.linkedin.com/shareArticle?mini=true&title=&summary=&source=&url='.$encodedUrl;
                 break;
+            case 'pinterest':
+                return 'https://www.pinterest.com/pin/create/link/?'.$encodedUrl;
+                break;
+            case 'stumbleupon':
+                return 'https://www.stumbleupon.com/submit/?'.$encodedUrl;
+                break;
+			case 'tumblr':
+				return 'https://www.tumblr.com/share/link?'.$encodedUrl;
+				break;
+			case 'reddit':
+				return 'http://www.reddit.com/submit?url='.$encodedUrl;
+				break;
             default:
                 return null;
         }


### PR DESCRIPTION
Some more work could be done on most of those links, eg the page title could often be included as a parameter. I see there are some other pull requests that do this for twitter. I don't have time right now to improve this further, and this is a good start, I think. 

Pinterest is also there, but commented out, since it requires an image URL, in addition to the page URL; it's not possible to share a page without an image URL on pinterest. 

It also won't show the sharing links for pages that don't have a URL, which it previously did. 