### PR TITLE
Fix for php 7.4 deprecation error

### DIFF
--- a/src/controllers/DefaultController.php
+++ b/src/controllers/DefaultController.php
@@ -66,7 +66,7 @@ class DefaultController extends Controller
                 return Craft::$app->view->renderString(
                     '{{ btns|raw }}',
                     [
-                        'btns' => implode($btns, ' | '),
+                        'btns' => implode( ' | ', $btns),
                     ]
                 );
             }


### PR DESCRIPTION
Using plug-in with php 7.4 throws a deprecation error, turning the params around solves the issue and is backwards compatible.

Le error:
yii\base\ErrorException · implode(): Passing glue string after array is deprecated. Swap the parameters
