### PR TITLE
Fix Craft 5 compatibility: Update sections service to entries

### DIFF
--- a/src/SimpleSharing.php
+++ b/src/SimpleSharing.php
@@ -96,7 +96,7 @@ class SimpleSharing extends Plugin
      */
     protected function settingsHtml(): string
     {
-        $sections = Craft::$app->sections->getAllSections();
+        $sections = Craft::$app->entries->getAllSections();
         $optionsSections = [];
 
         foreach ($sections as $section) {


### PR DESCRIPTION
## Summary
Fixes the plugin settings page error that occurs when accessing `/admin/settings/plugins/simple-sharing` on Craft 5.

## Changes
- Updated `Craft::$app->sections->getAllSections()` to `Craft::$app->entries->getAllSections()` on line 99 of `src/SimpleSharing.php`

## Issue
In Craft 5, the `sections` service has been moved to the `entries` service. The current code uses the old Craft 4 syntax which causes this error:

```
Getting unknown property: craft\web\Application::sections
```

## Testing
- Tested on Craft 5.0 with PHP 8.2
- Plugin settings page now loads correctly
- All functionality works as expected

Fixes #22